### PR TITLE
added power pc and little and big endian

### DIFF
--- a/webrtc/typedefs.h
+++ b/webrtc/typedefs.h
@@ -47,6 +47,12 @@
 #elif defined(__pnacl__)
 #define WEBRTC_ARCH_32_BITS
 #define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(__powerpc64__)
+#define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(__LITTLE_ENDIAN__)
+#define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(__BIG_ENDIAN__)
+#define WEBRTC_ARCH_BIG_ENDIAN
 #else
 #error Please add support for your architecture in typedefs.h
 #endif


### PR DESCRIPTION
I need to compile this on a ppc64le CPU, but it failed. The flags for __LITTLE_ENDIAN__ and __BIG_ENDIAN__ should be able to reduce the number of failed compilations for other platforms I believe.